### PR TITLE
Instalación de Docker de manera correcta

### DIFF
--- a/install-env.sh
+++ b/install-env.sh
@@ -3,7 +3,7 @@
 # Prepara el ambiente para que todo se pueda configurar.
 # Se debe ejecutar con root.
 #
-# Autor: Andres Gomez - AngocA
+# Autor: Andres Gomez - AngocA, Alvarado Ludwig - Ludway
 # Version: 2024-11-04
 declare -r VERSION="2024-11-04"
 
@@ -29,7 +29,7 @@ ambiente para su siguiente uso.
 
 El script se debe ejecutar como root.
 
-Autor: Andrés Gómez Casanova - AngocA
+Autor: Andrés Gómez Casanova - AngocA, Alvarado Ludwig - Ludway
 Version: ${VERSION}
 EOT
 }
@@ -99,8 +99,9 @@ function installTools() {
 function installODM() {
  apt install -y python3
  apt install -y python3-pip
- apt install -y docker
- apt install -y docker-compose
+ apt-get install ca-certificates curl
+ install -m 0755 -d /etc/apt/keyrings
+ curl -fsSL https://download.docker.com/linux/debian/gpg
 
  cd
 

--- a/install-env.sh
+++ b/install-env.sh
@@ -101,7 +101,14 @@ function installODM() {
  apt install -y python3-pip
  apt-get install ca-certificates curl
  install -m 0755 -d /etc/apt/keyrings
- curl -fsSL https://download.docker.com/linux/debian/gpg
+ curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+ chmod a+r /etc/apt/keyrings/docker.asc
+ echo \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+     tee /etc/apt/sources.list.d/docker.list > /dev/null
+ apt-get update
+ apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
  cd
 


### PR DESCRIPTION
Se siguen las instrucciones para instalar Docker desde el sitio oficial https://docs.docker.com/engine/install/debian/#install-using-the-repository 